### PR TITLE
feat: changes to allow adding a new atsign

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ Future<void> main() async {
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
-  // * load the AtClientPreference in the background
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -167,6 +167,12 @@ class DoOnboardWidget extends StatelessWidget {
             );
             break;
           case AtOnboardingResultStatus.cancel:
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const StartScreen(
+                        // futurePreference: this.futurePreference,
+                        )));
             break;
         }
       },

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -147,6 +147,7 @@ class DoOnboardWidget extends StatelessWidget {
             domain: AtEnv.rootDomain,
             appAPIKey: AtEnv.appApiKey,
           ),
+          isSwitchingAtsign: true,
         );
         switch (onboardingResult.status) {
           case AtOnboardingResultStatus.success:


### PR DESCRIPTION
add the onboarding config ```isSwitchingAtsign: true``` to the onboarding widget used in start_screen.dart

**- What I did**
In order for the onboarding widget to function properly, I need to let it know the intent was to add a new atSign to the keychain.

**- How I did it**
set the onboarding widget "isSwitchingAtsign" value to "true"
**- How to verify it**

**- Description for the changelog**
Updated the onboarding widget parameter for ```isSwitchingAtsign``` to ```true``` to ensure a new atSign can be added.