### PR TITLE
fix: reset onboarding widget after callbacks

### DIFF
--- a/lib/screens/secrets_list_screen.dart
+++ b/lib/screens/secrets_list_screen.dart
@@ -27,7 +27,7 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Secrets for ${widget.atSign}!',
+        title: Text('${widget.atSign}',
             style: TextStyle(
               overflow: TextOverflow.ellipsis,
               fontSize: 18,
@@ -51,9 +51,9 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 future: _keyChainManager.getPkamPublicKey(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
-                    keyString = snapshot.data!;
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -82,9 +82,9 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 future: _keyChainManager.getPkamPrivateKey(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
-                    keyString = snapshot.data!;
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -122,9 +122,9 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 future: _keyChainManager.getEncryptionPublicKey(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
-                    keyString = snapshot.data!;
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -153,9 +153,9 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 future: _keyChainManager.getEncryptionPrivateKey(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
-                    keyString = snapshot.data!;
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -190,9 +190,9 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 future: _keyChainManager.getSelfEncryptionAESKey(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
-                    keyString = snapshot.data!;
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -223,47 +223,15 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                 color: Colors.black,
               )),
           ListTile(
-            title: Text('Bootstrap Shared Secret'),
-            subtitle: FutureBuilder<String?>(
-                future: _keyChainManager.getCramSecret(widget.atSign),
-                builder:
-                    (BuildContext context, AsyncSnapshot<String?> snapshot) {
-                  String keyString = 'no keys found';
-                  if (snapshot.hasData) {
-                    keyString = snapshot.data!;
-                  } else if (snapshot.hasError) {
-                    keyString = snapshot.error.toString();
-                  }
-                  return Text(keyString,
-                      style: TextStyle(
-                        overflow: TextOverflow.ellipsis,
-                        fontSize: 14,
-                        color: Colors.black,
-                      ));
-                }),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => AtSecretValueScreen(
-                    atSign: widget.atSign,
-                    atSecretType: AtSecretType.bootstrapSharedSecret,
-                    // futurePreference: widget.futurePreference,
-                  ),
-                ),
-              );
-            },
-          ),
-          ListTile(
             title: Text('Local Persistence Encryption Secret'),
             subtitle: FutureBuilder<List<int>?>(
                 future: _keyChainManager.getKeyStoreSecret(widget.atSign),
                 builder:
                     (BuildContext context, AsyncSnapshot<List<int>?> snapshot) {
-                  String keyString = 'no keys found';
+                  String keyString = 'no key found';
                   if (snapshot.hasData) {
                     List<int>? charCodes = snapshot.data;
-                    keyString = charCodes.toString();
+                    if (charCodes!.isNotEmpty) keyString = charCodes.toString();
                   } else if (snapshot.hasError) {
                     keyString = snapshot.error.toString();
                   }
@@ -281,6 +249,39 @@ class _SecretsListScreenState extends State<SecretsListScreen> {
                   builder: (context) => AtSecretValueScreen(
                     atSign: widget.atSign,
                     atSecretType: AtSecretType.dataPersistenceKey,
+                    // futurePreference: widget.futurePreference,
+                  ),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: Text('Bootstrap Shared Secret'),
+            subtitle: FutureBuilder<String?>(
+                future: _keyChainManager.getCramSecret(widget.atSign),
+                builder:
+                    (BuildContext context, AsyncSnapshot<String?> snapshot) {
+                  String keyString =
+                      'Bootstrap complete, secret has been deleted';
+                  if (snapshot.hasData) {
+                    if (snapshot.data!.isNotEmpty) keyString = snapshot.data!;
+                  } else if (snapshot.hasError) {
+                    keyString = snapshot.error.toString();
+                  }
+                  return Text(keyString,
+                      style: TextStyle(
+                        overflow: TextOverflow.ellipsis,
+                        fontSize: 14,
+                        color: Colors.black,
+                      ));
+                }),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => AtSecretValueScreen(
+                    atSign: widget.atSign,
+                    atSecretType: AtSecretType.bootstrapSharedSecret,
                     // futurePreference: widget.futurePreference,
                   ),
                 ),

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -176,26 +176,25 @@ class DoOnboardWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       onPressed: () async {
+        AtOnboardingConfig atOnboardingConfig = AtOnboardingConfig(
+          atClientPreference: await loadAtClientPreference(),
+          rootEnvironment: AtEnv.rootEnvironment,
+          domain: AtEnv.rootDomain,
+          appAPIKey: AtEnv.appApiKey,
+        );
         AtOnboardingResult onboardingResult = await AtOnboarding.onboard(
           context: context,
-          config: AtOnboardingConfig(
-            atClientPreference: await loadAtClientPreference(),
-            rootEnvironment: AtEnv.rootEnvironment,
-            domain: AtEnv.rootDomain,
-            appAPIKey: AtEnv.appApiKey,
-          ),
+          config: atOnboardingConfig,
           isSwitchingAtsign: true,
         );
         switch (onboardingResult.status) {
           case AtOnboardingResultStatus.success:
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (_) => const StartScreen(
-                        // futurePreference: this.futurePreference,
-                        )));
+            AtOnboarding.reset(context: context, config: atOnboardingConfig);
+            Navigator.push(context,
+                MaterialPageRoute(builder: (_) => const StartScreen()));
             break;
           case AtOnboardingResultStatus.error:
+            AtOnboarding.reset(context: context, config: atOnboardingConfig);
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(
                 backgroundColor: Colors.red,
@@ -204,6 +203,7 @@ class DoOnboardWidget extends StatelessWidget {
             );
             break;
           case AtOnboardingResultStatus.cancel:
+            AtOnboarding.reset(context: context, config: atOnboardingConfig);
             Navigator.push(
                 context,
                 MaterialPageRoute(


### PR DESCRIPTION
Adding in reset onboarding widget after callbacks in oder to step sync chattiness

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
added in AtOnboarding.reset after each callback in order to stop synch chattiness (e.g. from some other app).

**- How I did it**
call AtOnboarding.reset after each callback

**- How to verify it**
1. run the app
2. add an atsign using backup keys
3. pair the same atsign with another app (e.g. atMospherePro) using the same backup keys
4. verify that sync messages no longer appear

**- Description for the changelog**

fix: After onboarding an atsign, sync continues to run which can be chatty. Using  AtOnboarding.reset to stop this.
